### PR TITLE
TASK-112

### DIFF
--- a/cypress/integration/unit/helpers/shift.helper.spec.ts
+++ b/cypress/integration/unit/helpers/shift.helper.spec.ts
@@ -24,6 +24,19 @@ const testData3: ShiftInfoModel = {
   "2": ["R", "R", "R"].map((d) => ShiftCode[d]),
 };
 
+const testData4: ShiftInfoModel = {
+  "0": ["R", "W", "R", "W"].map((d) => ShiftCode[d]),
+  "1": ["R", "R", "R", "W"].map((d) => ShiftCode[d]),
+  "2": ["R", "W", "R", "R"].map((d) => ShiftCode[d]),
+};
+const testData5: ShiftInfoModel = {
+  "0": ["R", "W", "R", "W"].map((d) => ShiftCode[d]),
+  "1": ["R", "R", "R", "W"].map((d) => ShiftCode[d]),
+  "2": ["P", "R", "R", "R"].map((d) => ShiftCode[d]),
+  "3": ["R", "W", "P", "R"].map((d) => ShiftCode[d]),
+  "4": ["D", "W", "R", "R"].map((d) => ShiftCode[d]),
+};
+
 const GetWorkersCountTestCases: GetWorkersCountTestCase[] = [
   {
     arr: testData1,
@@ -36,6 +49,14 @@ const GetWorkersCountTestCases: GetWorkersCountTestCase[] = [
   {
     arr: testData3,
     exp: [3, 3, 3],
+  },
+  {
+    arr: testData4,
+    exp: [3, 1, 3, 1],
+  },
+  {
+    arr: testData5,
+    exp: [5, 2, 5, 3],
   },
 ];
 //#endregion

--- a/src/helpers/shifts.helper.ts
+++ b/src/helpers/shifts.helper.ts
@@ -13,7 +13,8 @@ export class ShiftHelper {
   public static getWorkersCount(shifts: ShiftInfoModel): Array<number> {
     const shiftsArray = Object.values(shifts);
     const workersPerDays: Array<number> = [];
-    for (let i = 0; i < shiftsArray.length; i++) {
+    if (shiftsArray.length === 0) return [];
+    for (let i = 0; i < shiftsArray[0].length; i++) {
       workersPerDays.push(
         shiftsArray.reduce((a, b) => a + (this.shiftCodeToWorkTime(b[i]) ? 1 : 0), 0)
       );

--- a/src/logic/providers/foundation-info-provider.model.ts
+++ b/src/logic/providers/foundation-info-provider.model.ts
@@ -1,4 +1,3 @@
-import { ShiftInfoModel } from "../../common-models/shift-info.model";
 import { WorkerType } from "../../common-models/worker-info.model";
 import { ShiftHelper } from "../../helpers/shifts.helper";
 import { ChildrenInfoProvider } from "./children-info-provider.model";

--- a/src/logic/providers/foundation-info-provider.model.ts
+++ b/src/logic/providers/foundation-info-provider.model.ts
@@ -1,4 +1,5 @@
 import { ShiftInfoModel } from "../../common-models/shift-info.model";
+import { WorkerType } from "../../common-models/worker-info.model";
 import { ShiftHelper } from "../../helpers/shifts.helper";
 import { ChildrenInfoProvider } from "./children-info-provider.model";
 import { ExtraWorkersInfoProvider } from "./extra-workers-info-provider.model";
@@ -13,20 +14,16 @@ export interface FoundationInfoOptions extends Pick<Sections, "NurseInfo" | "Bab
 }
 
 export abstract class FoundationInfoProvider {
-  get workersShifts(): ShiftInfoModel {
-    return {
-      ...this.sections.BabysitterInfo.workerShifts,
-      ...this.sections.NurseInfo.workerShifts,
-    };
-  }
   get childrenInfo(): number[] {
     return this.sections.ChildrenInfo.registeredChildrenNumber;
   }
   get extraWorkersInfo(): number[] {
     return this.sections.ExtraWorkersInfo.extraWorkers;
   }
-  getWorkersCount(): number[] {
-    return ShiftHelper.getWorkersCount(this.workersShifts);
+  getWorkersCount(type: WorkerType): number[] {
+    if (type === WorkerType.NURSE) {
+      return ShiftHelper.getWorkersCount(this.sections.NurseInfo.workerShifts);
+    } else return ShiftHelper.getWorkersCount(this.sections.BabysitterInfo.workerShifts);
   }
 
   constructor(protected sections: FoundationInfoOptions) {}

--- a/src/logic/schedule-logic/foundation-info.logic.ts
+++ b/src/logic/schedule-logic/foundation-info.logic.ts
@@ -1,3 +1,4 @@
+import { WorkerType } from "../../common-models/worker-info.model";
 import { FoundationInfoProvider } from "../providers/foundation-info-provider.model";
 import { Sections } from "../providers/schedule-provider.model";
 import { FoundationSectionKey } from "../section.model";
@@ -20,8 +21,8 @@ export class FoundationInfoLogic
         FoundationSectionKey.ChildrenCount,
         this.sections.ChildrenInfo.registeredChildrenNumber
       ),
-      new DataRow(FoundationSectionKey.NurseCount, this.getWorkersCount()),
-      new DataRow(FoundationSectionKey.BabysittersCount, this.getWorkersCount()),
+      new DataRow(FoundationSectionKey.NurseCount, this.getWorkersCount(WorkerType.NURSE)),
+      new DataRow(FoundationSectionKey.BabysittersCount, this.getWorkersCount(WorkerType.OTHER)),
       new DataRow(
         FoundationSectionKey.ExtraWorkersCount,
         this.sections.ExtraWorkersInfo.extraWorkers


### PR DESCRIPTION
 workerCount are now using different data for nurses and babysitters. Removed error from route-buttons.component. Fixed missed columns in getWorkersCount in shifts.helper.ts

fixed table:
![image](https://user-images.githubusercontent.com/44201461/100545939-d3672900-325e-11eb-8858-ec9aa0d709fc.png)
