### PR TITLE
TASK-123 Test: sprawdzenie czy blędy z serwera są wyświetlane

### DIFF
--- a/cypress/fixtures/scheduleErrors.json
+++ b/cypress/fixtures/scheduleErrors.json
@@ -1,0 +1,20 @@
+[
+  {
+    "day":1,
+    "required":8,
+    "code":"WND",
+    "actual":5
+  },
+  {
+    "day":2,
+    "required":8,
+    "code":"WND",
+    "actual":0
+  },
+  {
+    "day":2,
+    "required":5,
+    "code":"WNN",
+    "actual":0
+  }
+]

--- a/cypress/integration/e2e/table/schedule-errors.spec.js
+++ b/cypress/integration/e2e/table/schedule-errors.spec.js
@@ -1,0 +1,26 @@
+/// <reference types="cypress" />
+
+context("Schedule errors", () => {
+  beforeEach(() => {
+    cy.server();
+    cy.fixture("scheduleErrors.json").then((json) => {
+      cy.route({
+        method: "POST",
+        url: "**/schedule_errors",
+        response: json,
+      });
+    });
+    cy.visit(Cypress.env("baseUrl"));
+    cy.contains("Plik").click();
+    cy.get('[data-cy="file-input"]').attachFile("example.xlsx");
+    cy.contains("Edytuj").click();
+  });
+
+  it("Should show errors returned by server", () => {
+    cy.contains("Sprawdź Plan").click();
+    cy.contains("Pokaż błędy").click();
+    cy.contains("Za mało pracowników w trakcie dnia w dniu 1, potrzeba 8, jest 5");
+    cy.contains("Za mało pracowników w trakcie dnia w dniu 2, potrzeba 8, jest 0");
+    cy.contains("Za mało pracowników w nocy w dniu 2, potrzeba 5, jest 0");
+  });
+});


### PR DESCRIPTION
Defaultowo w czasie CI cypress odpala testy w Electronie

Odpalanie testów lokalnie defaultowo jest w chromie (po zmienieniu wybrana przeglądarka jest zapamiętana na kolejne uruchomienia, ale nie da się ustawić defaultowej) można jedynie ograniczyć do samego Elektrona (wtedy dostępny będzie tylko electron)