### PR TITLE
[WIP] TASK-151 Drawer do edycji oraz dodawania pracownika

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1389,10 +1389,11 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@fast-csv/format": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.1.tgz",
-      "integrity": "sha512-Ap6KSt0iJlzrivZU4grQzDGGOQ+vN5kvUeOHLF1BE7nWri1auiodgS3SCffvLe1Zvu79tACe1tw3dyBADk1NsA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
       "requires": {
+        "@types/node": "^14.0.1",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isboolean": "^3.0.3",
         "lodash.isequal": "^4.5.0",
@@ -1401,10 +1402,11 @@
       }
     },
     "@fast-csv/parse": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.2.tgz",
-      "integrity": "sha512-smFKL1E00zy6SB+MIRL4kJq4ba4Is9mHEf+1kdMH7iLInrKszADyJFGicoRfiFTtAvm+661LJMWjyQHrmx6WeA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
       "requires": {
+        "@types/node": "^14.0.1",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.groupby": "^4.6.0",
         "lodash.isfunction": "^3.0.9",
@@ -7929,13 +7931,12 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-csv": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.2.tgz",
-      "integrity": "sha512-tmvVMsliprsl7P1z++XuhfGZPTz/h2sTLhs5PYVhtOSsu7t0T2q1TdWq/CORQsD9Cc2oPiTchpf7gACLXArNYQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
       "requires": {
-        "@fast-csv/format": "4.3.1",
-        "@fast-csv/parse": "4.3.2",
-        "@types/node": "^14.0.1"
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
       }
     },
     "fast-deep-equal": {
@@ -9411,9 +9412,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.3.3",

--- a/src/components/common-components/drawer/drawer.component.tsx
+++ b/src/components/common-components/drawer/drawer.component.tsx
@@ -1,22 +1,71 @@
-import { Drawer as MaterialDrawer, DrawerProps, IconButton } from "@material-ui/core";
+import {
+  Box,
+  Divider,
+  Drawer as MaterialDrawer,
+  DrawerProps,
+  Grid,
+  IconButton,
+} from "@material-ui/core";
 import { MdClose } from "react-icons/md";
-
 import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import ScssVars from "../../../assets/styles/styles/custom/_variables.module.scss";
+
+const useStyles = makeStyles({
+  drawer: {
+    minWidth: 500,
+  },
+  drawerContentMargin: {
+    paddingTop: 25,
+    paddingLeft: 24,
+    paddingRight: 24,
+    paddingBottom: 15,
+  },
+  exitButton: {
+    margin: "-7px -8px",
+    marginTop: -15,
+    color: ScssVars.primary,
+  },
+  title: {
+    fontFamily: ScssVars.fontFamilyPrimary,
+    fontWeight: 700,
+    fontSize: 18,
+    lineHeight: 1.1,
+    color: ScssVars.primary,
+  },
+});
 
 export interface DrawerOptions extends DrawerProps {
   title: string;
   setOpen: (open: boolean) => void;
 }
+
 export default function Drawer(options: DrawerOptions): JSX.Element {
+  const classes = useStyles();
   const { title, setOpen, children, ...otherOptions } = options;
 
   return (
-    <MaterialDrawer {...otherOptions} anchor={"right"}>
-      <h1>{title}</h1>
-      <IconButton onClick={(): void => setOpen(false)}>
-        <MdClose />
-      </IconButton>
-      {children}
+    <MaterialDrawer classes={{ paper: classes.drawer }} {...otherOptions} anchor={"right"}>
+      <Grid
+        container
+        className={classes.drawerContentMargin}
+        direction="row"
+        justify="space-between"
+        alignItems="center"
+      >
+        <Grid item>
+          <h1 className={classes.title}>{title}</h1>
+        </Grid>
+        <Grid item>
+          <IconButton className={classes.exitButton} onClick={(): void => setOpen(false)}>
+            <MdClose />
+          </IconButton>
+        </Grid>
+      </Grid>
+
+      <Divider />
+
+      <Box className={classes.drawerContentMargin}>{children}</Box>
     </MaterialDrawer>
   );
 }

--- a/src/components/workers-page/workers-tab/worker-drawer.component.tsx
+++ b/src/components/workers-page/workers-tab/worker-drawer.component.tsx
@@ -14,7 +14,7 @@ interface WorkerDrawerOptions extends Omit<DrawerOptions, "title"> {
 
 export default function WorkerDrawerComponent(options: WorkerDrawerOptions): JSX.Element {
   const { mode, worker, setOpen, ...otherOptions } = options;
-  const title = mode === WorkerDrawerMode.ADD_NEW ? "Dodaj pracownika" : "Edytuj pracownika";
+  const title = mode === WorkerDrawerMode.ADD_NEW ? "Dodaj pracownika" : "Edycja pracownika";
 
   return (
     <Drawer setOpen={setOpen} title={title} {...otherOptions}>


### PR DESCRIPTION
Drawer w dwóch podobnych wersjach:
* dodawanie pracownika (bez części zmiany spoko i niespoko)
* edycja pracownika
* jeśli chodzi o wymiar pracy, to select Umowa ma dwie opcje UoP i Zlecenie. Dla UoP pojawia się po prawej select z dwoma ułamkami etatu (1/1 i 1/2 oraz opcja inne, która pozwala na wpisanie innego ułamka), dla zlecenia pole do wpisania godzin do wyrobienia w miesiącu (wpisanie ułamka Tomek już robił)
* UoP i zlecenia mają być konwertowalne, czyli po zmianie typu umowy, ma automatycznie ustawić się odpowiednia ilość godzin/ułamek
