### PR TITLE
TASK-162 Fix work hours info calculation

### DIFF
--- a/cypress/integration/unit/helpers/shift.helper.spec.ts
+++ b/cypress/integration/unit/helpers/shift.helper.spec.ts
@@ -193,19 +193,48 @@ describe("ShiftHelper", () => {
 
   CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
     describe("caclulateWorkHoursInfo", () => {
-      const message = `${testCase.dates.length} ${testCase.shifts.length}  should calculate correct work hours for ${testCase.shifts}`;
-      it(message, () => {
+      describe("for standard holidays", () => {
+        const message = `${testCase.dates.length} ${testCase.shifts.length}  should calculate correct work hours for ${testCase.shifts}`;
+        it(message, () => {
+          const expectedOvertime =
+            testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
+          const hours = ShiftHelper.caclulateWorkHoursInfo(
+            testCase.shifts,
+            testCase.workerNorm,
+            testCase.dates,
+            month
+          );
+          expect(hours).to.eql([
+            testCase.expectedRequiredHours,
+            testCase.expectedActualWorkHours,
+            expectedOvertime,
+          ]);
+        });
+      });
+    });
+  });
+  describe("calculateWorkHoursInfo for case with additional holiday on Saturday", () => {
+    const saturdayHoliday = {
+      month: month,
+      dayOfWeek: WeekDay.SA,
+      isPublicHoliday: true,
+    };
+    const saturdayHolidayCaseWeekends = [...weekends.slice(0, -1), saturdayHoliday];
+    const datesWithSaturdayHoliday = [...saturdayHolidayCaseWeekends, ...holidays, ...workDays];
+
+    CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
+      it(`should subtract 8 from required hours and add 8 to overtime for ${testCase.shifts}`, () => {
         const expectedOvertime = testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
         const hours = ShiftHelper.caclulateWorkHoursInfo(
           testCase.shifts,
           testCase.workerNorm,
-          testCase.dates,
+          datesWithSaturdayHoliday,
           month
         );
         expect(hours).to.eql([
-          testCase.expectedRequiredHours,
+          testCase.expectedRequiredHours - 8,
           testCase.expectedActualWorkHours,
-          expectedOvertime,
+          expectedOvertime + 8,
         ]);
       });
     });

--- a/cypress/integration/unit/helpers/shift.helper.spec.ts
+++ b/cypress/integration/unit/helpers/shift.helper.spec.ts
@@ -61,9 +61,11 @@ const GetWorkersCountTestCases: GetWorkersCountTestCase[] = [
 ];
 //#endregion
 
+type DateArray = Pick<VerboseDate, "isPublicHoliday" | "dayOfWeek" | "month">[];
+
 //#region caclulateWorkHoursInfo
 type CaclulateWorkHoursInfoTestData = {
-  dates: Pick<VerboseDate, "isPublicHoliday" | "dayOfWeek" | "month">[];
+  dates: DateArray;
   shifts: ShiftCode[];
   workerNorm: number;
   expectedActualWorkHours: number;
@@ -81,6 +83,12 @@ const weekendTemplate = {
   month: month,
   dayOfWeek: WeekDay.SU,
   isPublicHoliday: false,
+};
+
+const saturdayHolidayTemplate = {
+  month: month,
+  dayOfWeek: WeekDay.SA,
+  isPublicHoliday: true,
 };
 
 const holidayTemplate = {
@@ -198,45 +206,44 @@ describe("ShiftHelper", () => {
         it(message, () => {
           const expectedOvertime =
             testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
-          const hours = ShiftHelper.caclulateWorkHoursInfo(
-            testCase.shifts,
-            testCase.workerNorm,
-            testCase.dates,
-            month
-          );
-          expect(hours).to.eql([
-            testCase.expectedRequiredHours,
-            testCase.expectedActualWorkHours,
-            expectedOvertime,
-          ]);
+          testForCorrectWorkHourCalculation(testCase, expectedOvertime);
         });
       });
     });
   });
-  describe("calculateWorkHoursInfo for case with additional holiday on Saturday", () => {
-    const saturdayHoliday = {
-      month: month,
-      dayOfWeek: WeekDay.SA,
-      isPublicHoliday: true,
-    };
-    const saturdayHolidayCaseWeekends = [...weekends.slice(0, -1), saturdayHoliday];
+  describe("for case with additional holiday on Saturday", () => {
+    const saturdayHolidayCaseWeekends = [...weekends.slice(0, -1), saturdayHolidayTemplate];
     const datesWithSaturdayHoliday = [...saturdayHolidayCaseWeekends, ...holidays, ...workDays];
 
     CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
       it(`should subtract 8 from required hours and add 8 to overtime for ${testCase.shifts}`, () => {
         const expectedOvertime = testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
-        const hours = ShiftHelper.caclulateWorkHoursInfo(
-          testCase.shifts,
-          testCase.workerNorm,
-          datesWithSaturdayHoliday,
-          month
-        );
-        expect(hours).to.eql([
-          testCase.expectedRequiredHours - 8,
-          testCase.expectedActualWorkHours,
+        testForCorrectWorkHourCalculation(
+          testCase,
           expectedOvertime + 8,
-        ]);
+          testCase.expectedRequiredHours - 8,
+          datesWithSaturdayHoliday
+        );
       });
     });
   });
 });
+
+function testForCorrectWorkHourCalculation(
+  testCase: CaclulateWorkHoursInfoTestData,
+  expectedOvertimeHours: number,
+  expectedRequiredHours?: number,
+  dates?: DateArray
+): void {
+  const hours = ShiftHelper.caclulateWorkHoursInfo(
+    testCase.shifts,
+    testCase.workerNorm,
+    dates ? dates : testCase.dates,
+    month
+  );
+  expect(hours).to.eql([
+    expectedRequiredHours ? expectedRequiredHours : testCase.expectedRequiredHours,
+    testCase.expectedActualWorkHours,
+    expectedOvertimeHours,
+  ]);
+}

--- a/cypress/integration/unit/helpers/shift.helper.spec.ts
+++ b/cypress/integration/unit/helpers/shift.helper.spec.ts
@@ -199,9 +199,9 @@ describe("ShiftHelper", () => {
     });
   });
 
-  CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
-    describe("caclulateWorkHoursInfo", () => {
-      describe("for standard holidays", () => {
+  describe("caclulateWorkHoursInfo", () => {
+    describe("for standard holidays", () => {
+      CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
         const message = `${testCase.dates.length} ${testCase.shifts.length}  should calculate correct work hours for ${testCase.shifts}`;
         it(message, () => {
           const expectedOvertime =
@@ -210,20 +210,45 @@ describe("ShiftHelper", () => {
         });
       });
     });
-  });
-  describe("for case with additional holiday on Saturday", () => {
-    const saturdayHolidayCaseWeekends = [...weekends.slice(0, -1), saturdayHolidayTemplate];
-    const datesWithSaturdayHoliday = [...saturdayHolidayCaseWeekends, ...holidays, ...workDays];
+    describe("for cases with additional holiday on Saturday", () => {
+      describe("for case with 1 such holiday", () => {
+        const saturdayHolidayCaseWeekends = [...weekends.slice(0, -1), saturdayHolidayTemplate];
+        const datesWithSaturdayHoliday = [...saturdayHolidayCaseWeekends, ...holidays, ...workDays];
 
-    CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
-      it(`should subtract 8 from required hours and add 8 to overtime for ${testCase.shifts}`, () => {
-        const expectedOvertime = testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
-        testForCorrectWorkHourCalculation(
-          testCase,
-          expectedOvertime + 8,
-          testCase.expectedRequiredHours - 8,
-          datesWithSaturdayHoliday
-        );
+        CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
+          it(`should subtract 8 from required hours and add 8 to overtime for ${testCase.shifts}`, () => {
+            const expectedOvertime =
+              testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
+            testForCorrectWorkHourCalculation(
+              testCase,
+              expectedOvertime + 8,
+              testCase.expectedRequiredHours - 8,
+              datesWithSaturdayHoliday
+            );
+          });
+        });
+      });
+      describe("for case with 3 such holidays", () => {
+        const saturdayHolidayCaseWeekends = [
+          ...weekends.slice(0, -3),
+          saturdayHolidayTemplate,
+          saturdayHolidayTemplate,
+          saturdayHolidayTemplate,
+        ];
+        const datesWithSaturdayHoliday = [...saturdayHolidayCaseWeekends, ...holidays, ...workDays];
+
+        CaclulateWorkHoursInfoTestCases.forEach((testCase) => {
+          it(`should subtract 24 from required hours and add 24 to overtime for ${testCase.shifts}`, () => {
+            const expectedOvertime =
+              testCase.expectedActualWorkHours - testCase.expectedRequiredHours;
+            testForCorrectWorkHourCalculation(
+              testCase,
+              expectedOvertime + 24,
+              testCase.expectedRequiredHours - 24,
+              datesWithSaturdayHoliday
+            );
+          });
+        });
       });
     });
   });

--- a/src/helpers/shifts.helper.ts
+++ b/src/helpers/shifts.helper.ts
@@ -81,7 +81,11 @@ export class ShiftHelper {
     const workingData = monthData.filter(
       (d) => VerboseDateHelper.isWorkingDay(d[1]!) && !this.isNotWorkingShift(d[0]!)
     );
-    const requiredHours = workerNorm * WORK_HOURS_PER_DAY * workingData.length;
+    const holidaySaturdaysCount = monthData.filter((d) =>
+      VerboseDateHelper.isHolidaySaturday(d[1]!)
+    ).length;
+    const requiredHours =
+      workerNorm * WORK_HOURS_PER_DAY * (workingData.length - holidaySaturdaysCount);
     const actualHours = monthData.reduce(
       (a, s) => a + workerNorm * this.shiftCodeToWorkTime(s[0]!),
       0

--- a/src/helpers/shifts.helper.ts
+++ b/src/helpers/shifts.helper.ts
@@ -78,14 +78,14 @@ export class ShiftHelper {
     }
     const firstDayOfCurrentMonth = dates.findIndex((d) => d.month === currentMonth);
     const monthData = ArrayHelper.zip(shifts, dates).slice(firstDayOfCurrentMonth);
-    const workingData = monthData.filter(
+    const workingDaysCount = monthData.filter(
       (d) => VerboseDateHelper.isWorkingDay(d[1]!) && !this.isNotWorkingShift(d[0]!)
-    );
+    ).length;
     const holidaySaturdaysCount = monthData.filter((d) =>
       VerboseDateHelper.isHolidaySaturday(d[1]!)
     ).length;
     const requiredHours =
-      workerNorm * WORK_HOURS_PER_DAY * (workingData.length - holidaySaturdaysCount);
+      workerNorm * WORK_HOURS_PER_DAY * (workingDaysCount - holidaySaturdaysCount);
     const actualHours = monthData.reduce(
       (a, s) => a + workerNorm * this.shiftCodeToWorkTime(s[0]!),
       0

--- a/src/helpers/verbose-date.helper.ts
+++ b/src/helpers/verbose-date.helper.ts
@@ -13,6 +13,13 @@ export class VerboseDateHelper {
     );
   }
 
+  static isHolidaySaturday(date?: Pick<VerboseDate, "isPublicHoliday" | "dayOfWeek">): boolean {
+    if (!date) {
+      return false;
+    }
+    return date.isPublicHoliday && date.dayOfWeek === WeekDay.SA;
+  }
+
   static getDayColor(
     day?: VerboseDate,
     defaultColorSet: CellColorSet = ColorHelper.DEFAULT_COLOR_SET,


### PR DESCRIPTION
Co było źle: jeśli sobota była dniem wolnym od pracy (świętem), nie powodowało to zmniejszenia liczby godzin wymaganych do przepracowania.

Jak (na nasze obecne zrozumienie kodeksu pracy) powinno być: tylko święta wypadające w niedzielę nie powinny obniżać liczby wymaganych godzin.

Co zrobiłem: dodałem testy sprawdzające źle obsługiwane przypadki i poprawiłem logikę tak, żeby przechodziły.