### PR TITLE
TASK-217 Self-host gitrunners on AGH servers

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -28,5 +28,5 @@ jobs:
         working-directory: ${{env.frontend-folder}}
 
       - name: Run cypress
-        run: npx cypress run --record --key 9e055824-71df-490e-adef-d984dff9e547
+        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --parallel
         working-directory: ${{env.frontend-folder}}

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  cypress-run:
+  cypress:
     name: Cypress run
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       frontend-folder: .
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -1,32 +1,31 @@
 name: CI
 
-on:
-  push:
-    branches: [ master, develop ]
-  pull_request:
-    branches: [ master, develop ]
+on: [push]
 
 jobs:
-  build:
+  cypress-run:
+    name: Cypress run
     runs-on: self-hosted
-    env:
-      frontend-folder: .
-
+    strategy:
+        fail-fast: false
+        matrix:
+            containers: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v2
+        - name: Checkout
+          uses: actions/checkout@v2
 
-      - name: Instal npm packages
-        run: npm install
-        working-directory: ${{env.frontend-folder}}
+        - name: Install npm packages
+          run: npm install
 
-      - name: Run application
-        run: npm start &
-        working-directory: ${{env.frontend-folder}}
+        - name: Run lint
+          run: npm run lint-warn
 
-      - name: Run lint
-        run: npm run lint-warn
-        working-directory: ${{env.frontend-folder}}
-
-      - name: Run cypress
-        run: npx cypress run --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --parallel
-        working-directory: ${{env.frontend-folder}}
+        - name: Run cypress
+          uses: cypress-io/github-action@v2
+          with:
+              record: true
+              parallel: true
+              start: npm start
+          env:
+              CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -4,28 +4,25 @@ on: [push]
 
 jobs:
   cypress:
-    name: Cypress run
+    name: Cypress check
     runs-on: self-hosted
     strategy:
         fail-fast: false
         matrix:
             containers: [1, 2, 3, 4, 5]
     steps:
-        - name: Checkout
+        - name: Checkout project
           uses: actions/checkout@v2
 
-        - name: Install npm packages
-          run: npm install
-
-        - name: Run lint
-          run: npm run lint-warn
-
-        - name: Run cypress
+        - name: Run Cypress
           uses: cypress-io/github-action@v2
           with:
+              group: 'Nurse project workers'
               record: true
               parallel: true
               start: npm start
+              borwser: chrome
+              headless: true
           env:
               CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -14,12 +14,6 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
 
-        - name: Install npm packages
-          run: npm install
-
-        - name: Run lint
-          run: npm run lint-warn
-
         - name: Run cypress
           uses: cypress-io/github-action@v2
           with:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -14,6 +14,12 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
 
+        - name: Install npm packages
+          run: npm install
+
+        - name: Run lint
+          run: npm run lint-warn
+
         - name: Run cypress
           uses: cypress-io/github-action@v2
           with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
               record: true
               parallel: true
               start: npm start
-              browser: chrome
+              browser: electron
               headless: true
           env:
               CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
               record: true
               parallel: true
               start: npm start
-              borwser: chrome
+              browser: chrome
               headless: true
           env:
               CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "cypress"
+  ],
+  "extends": [
+    "plugin:cypress/recommended"
+  ]
+}

--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "cypress"
-  ],
-  "extends": [
-    "plugin:cypress/recommended"
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4148,7 +4148,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
       "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "boxen": {
       "version": "4.2.0",


### PR DESCRIPTION
Zmniejszamy czas CI z 7 do niecałych 3 min, zaszalałem i zrobiłem 5 kontenerów z runnerami :) (Cypress mi mów ze jak zrobie jesze 2 to będzie jeszcze 10 sekund krócej, aj kusi). Dodałem jeszcze jakiś dziwny plugin z eslinem, ale nie wiem czy potrzebnie, dajcie znać. 

https://github.com/cypress-io/eslint-plugin-cypress