### PR TITLE
TASK-361 Fix dropdown positioning behavior

### DIFF
--- a/cypress/integration/e2e/table/load-schedule.spec.ts
+++ b/cypress/integration/e2e/table/load-schedule.spec.ts
@@ -4,7 +4,7 @@
 
 import { ShiftCode } from "../../../../src/common-models/shift-info.model";
 import { WorkerType } from "../../../../src/common-models/worker-info.model";
-import { FoundationInfoRowType, ScheduleName } from "../../../support/commands";
+import { FoundationInfoRowType } from "../../../support/commands";
 //#region Test data
 interface CheckFoundationInfoReadCorrectly {
   scheduleName: "childrens_extraworkers.xlsx" | "extraworkers_childrens.xlsx";

--- a/src/assets/styles/styles/custom/_autocomplete.scss
+++ b/src/assets/styles/styles/custom/_autocomplete.scss
@@ -30,7 +30,6 @@
     min-height: 25px;
     letter-spacing: 0.75px;
     &:hover {
-      font-style: italic;
       font-weight: $font-weight-extra-bold;
       cursor: pointer;
     }

--- a/src/assets/styles/styles/custom/_header.scss
+++ b/src/assets/styles/styles/custom/_header.scss
@@ -12,8 +12,7 @@
   justify-content: space-around;
   position: fixed;
   top: 0;
-  z-index: 500;
-  //z-index: 1301;
+  z-index: 2;
 
   #AssignmentIndIcon {
     color: $header-text-color;

--- a/src/components/common-components/autocomplete/autocomplete.component.tsx
+++ b/src/components/common-components/autocomplete/autocomplete.component.tsx
@@ -19,6 +19,7 @@ interface AutocompleteOptions<T> {
  * @important Dropdown create by this function is always opened.
  * To close the dropdown, you should destroy this component
  */
+
 export function AutocompleteComponent<T>({
   className,
   options,
@@ -40,7 +41,6 @@ export function AutocompleteComponent<T>({
       onValueChange(value);
     }
   }, [value, onValueChange]);
-
   const {
     getRootProps,
     getInputProps,
@@ -61,12 +61,12 @@ export function AutocompleteComponent<T>({
           value={value && getOptionLabel(value)}
           {...getInputProps()}
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>): void => {
-            forceUpdate && forceUpdate();
-            onKeyDown && onKeyDown(e);
+            forceUpdate?.();
+            onKeyDown?.(e);
           }}
         />
       </div>
-      {groupedOptions.length > 0 ? (
+      {groupedOptions.length > 0 && (
         <ul
           ref={tooltipRef}
           className={classNames("listbox")}
@@ -93,7 +93,7 @@ export function AutocompleteComponent<T>({
             </li>
           ))}
         </ul>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/components/common-components/autocomplete/autocomplete.component.tsx
+++ b/src/components/common-components/autocomplete/autocomplete.component.tsx
@@ -15,9 +15,8 @@ interface AutocompleteOptions<T> {
   className: string;
 }
 /**
- * Creates a dropdown with value set to options.
- * Important!
- * Dropdown create by this function is always opened.
+ * @description Creates a dropdown with value set to options.
+ * @important Dropdown create by this function is always opened.
  * To close the dropdown, you should destroy this component
  */
 export function AutocompleteComponent<T>({
@@ -30,8 +29,9 @@ export function AutocompleteComponent<T>({
 }: AutocompleteOptions<T>): JSX.Element {
   const inputRef = useRef(null);
   const tooltipRef = useRef(null);
-  const { styles } = usePopper(inputRef.current, tooltipRef.current, {
-    placement: "right-end",
+  const { styles, forceUpdate } = usePopper(inputRef.current, tooltipRef.current, {
+    placement: "auto",
+    strategy: "absolute",
   });
 
   const [value, setValue] = useState<T>();
@@ -60,7 +60,10 @@ export function AutocompleteComponent<T>({
           autoFocus={true}
           value={value && getOptionLabel(value)}
           {...getInputProps()}
-          onKeyDown={onKeyDown}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>): void => {
+            forceUpdate && forceUpdate();
+            onKeyDown && onKeyDown(e);
+          }}
         />
       </div>
       {groupedOptions.length > 0 ? (

--- a/src/components/common-components/folding-section/folding-section.component.tsx
+++ b/src/components/common-components/folding-section/folding-section.component.tsx
@@ -9,7 +9,12 @@ interface FoldingSectionOptions {
   name: string;
   children: ReactNode;
 }
-
+/**
+ * @description Function component which provides collapsing functionaliny for underlying children elements
+ * @param name - section name
+ * @param children - children elements
+ * @returns JSX.Element
+ */
 export function FoldingSection({ name, children }: FoldingSectionOptions): JSX.Element {
   const [opened, setOpened] = useState(false);
   return (
@@ -25,7 +30,7 @@ export function FoldingSection({ name, children }: FoldingSectionOptions): JSX.E
         </div>
         <hr className="middle" />
       </div>
-      {opened && children}
+      <div style={{ height: opened ? "initial" : "none" }}>{children}</div>
     </div>
   );
 }

--- a/src/components/schedule-page/table/schedule/schedule-parts/base-row.component.tsx
+++ b/src/components/schedule-page/table/schedule/schedule-parts/base-row.component.tsx
@@ -48,32 +48,30 @@ export function BaseRowComponent(options: BaseRowOptions): JSX.Element {
   }
 
   return (
-    <tr className="row scheduleStyle" id="mainRow" data-cy={baseRowDataCy(rowIndex)}>
-      {data.map((dataItem = { value: defaultEmpty }, cellIndex) => {
-        return (
-          <CellComponent
-            {...{
-              ...options,
-              ...dataItem,
-            }}
-            cellIndex={cellIndex}
-            key={`${dataItem.value}_${cellIndex}_${uuid}`}
-            isSelected={selection[cellIndex]}
-            isPointerOn={cellIndex === pointerPosition}
-            isBlocked={!isEditable || isCellFromPrevMonth(cellIndex, firstMonthDayIndex)}
-            onKeyDown={(event): void => onKeyDown?.(cellIndex, event)}
-            onValueChange={saveValue}
-            onClick={(): void => onClick?.(cellIndex)}
-            verboseDate={verboseDates?.[cellIndex]}
-            errorSelector={(scheduleErrors): ScheduleError[] =>
-              errorSelector?.(cellIndex, scheduleErrors) ?? []
-            }
-            onDrag={(pivot): void => onDrag?.(pivot, cellIndex)}
-            onDragEnd={(): void => onDragEnd?.(rowIndex, cellIndex)}
-            monthNumber={currMonthNumber}
-          />
-        );
-      })}
-    </tr>
+    <div className="row scheduleStyle" id="mainRow" data-cy={baseRowDataCy(rowIndex)}>
+      {data.map((dataItem = { value: defaultEmpty }, cellIndex) => (
+        <CellComponent
+          {...{
+            ...options,
+            ...dataItem,
+          }}
+          cellIndex={cellIndex}
+          key={`${dataItem.value}_${cellIndex}_${uuid}`}
+          isSelected={selection[cellIndex]}
+          isPointerOn={cellIndex === pointerPosition}
+          isBlocked={!isEditable || isCellFromPrevMonth(cellIndex, firstMonthDayIndex)}
+          onKeyDown={(event): void => onKeyDown?.(cellIndex, event)}
+          onValueChange={saveValue}
+          onClick={(): void => onClick?.(cellIndex)}
+          verboseDate={verboseDates?.[cellIndex]}
+          errorSelector={(scheduleErrors): ScheduleError[] =>
+            errorSelector?.(cellIndex, scheduleErrors) ?? []
+          }
+          onDrag={(pivot): void => onDrag?.(pivot, cellIndex)}
+          onDragEnd={(): void => onDragEnd?.(rowIndex, cellIndex)}
+          monthNumber={currMonthNumber}
+        />
+      ))}
+    </div>
   );
 }

--- a/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
+++ b/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
@@ -76,7 +76,7 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
   const hasNextClass = "hasNext" + hasNext;
 
   function _onValueChange(inputValue: string): void {
-    onValueChange && onValueChange(getShiftCode(inputValue));
+    onValueChange?.(getShiftCode(inputValue));
   }
 
   const selectableItemRef = useCellSelection(options);
@@ -104,10 +104,12 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
     ),
     [isBlocked, onClick]
   );
+  const pageOffset: number = document.getElementById("root")?.children[0].children[0].scrollTop!;
+  let clearModal;
 
   //  #region view
   return (
-    <td
+    <div
       ref={mergeRefs([selectableItemRef, componentContainer])}
       className={classNames("mainCell", {
         selection: isSelected || (isComponentVisible && isBlocked),
@@ -116,10 +118,17 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
       onClick={(): void => {
         toggleComponentVisibility();
       }}
+      onMouseEnter={(): void => {
+        clearTimeout(clearModal);
+      }}
       onMouseLeave={(): void => {
-        setTimeout(() => {
+        clearModal = setTimeout(() => {
           setIsComponentVisible(false);
-        }, 1500);
+        }, 900);
+      }}
+      onWheel={(e: React.WheelEvent<HTMLTableCellElement>): void => {
+        pageOffset !== document.getElementById("root")?.children[0].children[0].scrollTop &&
+          setIsComponentVisible(false);
       }}
       id={id}
       onBlur={(): void => {
@@ -128,12 +137,14 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
     >
       {showInput && (
         <WrapContentDiv>
-          <CellInput
-            input={ShiftAutocompleteComponent}
-            onKeyDown={onKeyDown}
-            onValueChange={_onValueChange}
-            {...options}
-          />
+          {isComponentVisible && (
+            <CellInput
+              input={ShiftAutocompleteComponent}
+              onKeyDown={onKeyDown}
+              onValueChange={_onValueChange}
+              {...options}
+            />
+          )}
         </WrapContentDiv>
       )}
       <ErrorTooltipProvider
@@ -177,7 +188,7 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
         </Popper>
       )}
       )
-    </td>
+    </div>
   );
 }
 

--- a/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
+++ b/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
@@ -116,7 +116,7 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
         blocked: isBlocked,
       })}
       onClick={(): void => {
-        toggleComponentVisibility();
+        (!isComponentVisible || !isEditMode) && toggleComponentVisibility();
       }}
       onMouseEnter={(): void => {
         clearTimeout(clearModal);

--- a/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
+++ b/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
@@ -31,7 +31,11 @@ interface ShiftCellOptions extends BaseCellOptions {
 export function getColor(value: string): string {
   return Object.values(SHIFTS).filter((s) => s.code === value)[0].color ?? "FFD100";
 }
-
+/**
+ * @description Function component that creates cell containing Details or Autocomplete when in edit mode
+ * @param option : ShiftCellOption
+ * @returns JSX.Element
+ */
 export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
   const {
     cellIndex,
@@ -109,7 +113,14 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
         selection: isSelected || (isComponentVisible && isBlocked),
         blocked: isBlocked,
       })}
-      onClick={(): void => toggleComponentVisibility()}
+      onClick={(): void => {
+        toggleComponentVisibility();
+      }}
+      onMouseLeave={(): void => {
+        setTimeout(() => {
+          setIsComponentVisible(false);
+        }, 1500);
+      }}
       id={id}
       onBlur={(): void => {
         onBlur?.();

--- a/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
+++ b/src/components/schedule-page/table/schedule/schedule-parts/shift-cell/shift-cell.component.tsx
@@ -124,7 +124,7 @@ export function ShiftCellComponentF(options: ShiftCellOptions): JSX.Element {
       onMouseLeave={(): void => {
         clearModal = setTimeout(() => {
           setIsComponentVisible(false);
-        }, 900);
+        }, 444);
       }}
       onWheel={(e: React.WheelEvent<HTMLTableCellElement>): void => {
         pageOffset !== document.getElementById("root")?.children[0].children[0].scrollTop &&

--- a/src/components/schedule-page/table/schedule/sections/shifts-section/shifts-section.component.tsx
+++ b/src/components/schedule-page/table/schedule/sections/shifts-section/shifts-section.component.tsx
@@ -46,18 +46,16 @@ export function ShiftsSectionComponent(options: ShiftsSectionOptions): JSX.Eleme
     workerType === WorkerType.NURSE ? "NurseInfo" : "BabysitterInfo";
 
   return (
-    <>
-      <table>
-        <BaseSectionComponent
-          {...options}
-          key={uuid}
-          data={data}
-          sectionKey={sectionKey}
-          cellComponent={ShiftCellComponent}
-          rowComponent={ShiftRowComponent}
-          errorSelector={shiftSectionErrorSelector}
-        />
-      </table>
-    </>
+    <div>
+      <BaseSectionComponent
+        {...options}
+        key={uuid}
+        data={data}
+        sectionKey={sectionKey}
+        cellComponent={ShiftCellComponent}
+        rowComponent={ShiftRowComponent}
+        errorSelector={shiftSectionErrorSelector}
+      />
+    </div>
   );
 }


### PR DESCRIPTION

Naprawiłem pozycjonowanie modala po wprowadzaniu danych do inputa. Teraz popper cellDetails znika po 1.5s od opuszczenia obszaru cella lub cellDetails poppera. Zmieniłem zIndex hedera z 500 na 2 aby każdy komponent biblioteki react-propper mógł się wyświetlać ponad resztą.