### PR TITLE
TASK-386 Enhance comprehensibility of error messages (follow on)

### DIFF
--- a/src/helpers/error-message.helper.ts
+++ b/src/helpers/error-message.helper.ts
@@ -142,9 +142,7 @@ export class ErrorMessageHelper {
         title = `${error.worker}`;
         break;
       case AlgorithmErrorCode.WorkerUnderTime:
-        message = `Pracownik ma <b>${error.hours}</b> niedo${TranslationHelper.hourAccusativus(
-          error.hours
-        )}.`;
+        message = `<b>${error.hours}</b> niedo${TranslationHelper.hourAccusativus(error.hours)}`;
         type = ScheduleErrorType.WUH;
         title = `${error.worker}`;
         break;

--- a/src/logic/schedule-parser/metadata.parser.ts
+++ b/src/logic/schedule-parser/metadata.parser.ts
@@ -20,7 +20,7 @@ export class MetaDataParser extends MetadataProvider {
     } else {
       this.offset = 1;
       this.logLoadFIleError(
-        "Nie znaleziono nagłówka z <b>informacją o datach</b>. Jako pierwszy dzień miesiąca wczytano pierwszą kolumnę grafiku."
+        "Nie znaleziono nagłówka z <b>informacją o datach</b>. Jako pierwszy dzień miesiąca wczytano pierwszą kolumnę grafiku uzupełnioną wartościami zmian."
       );
     }
 


### PR DESCRIPTION
Zostało domergowane zanim wprowadziłam poprawki 😛

Co jeszcze zmieniłam:
Niedogodziny (to, co Aga pisała na Slacku):
![niedogodziny](https://user-images.githubusercontent.com/48785655/112633612-d8696d00-8e39-11eb-90e7-665dffdd9ef7.png)

Doprecyzowanie dot. pierwszej kolumny (bo pierwszą kolumną faktycznie są nazwy pracowników):
![inf o datach](https://user-images.githubusercontent.com/48785655/112633620-dacbc700-8e39-11eb-97d5-d6114143e14a.png)
