### PR TITLE
TASK 512 bad export of worker absense

### DIFF
--- a/src/logic/schedule-exporter/workers-absence-export.logic.ts
+++ b/src/logic/schedule-exporter/workers-absence-export.logic.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import xlsx from "exceljs";
+import * as _ from "lodash";
 import { ABSENCE_HEADERS, EMPTY_ROW } from "../../helpers/parser.helper";
 import { TranslationHelper } from "../../helpers/translations.helper";
 import { PrimaryMonthRevisionDataModel } from "../../state/application-state.model";
@@ -59,7 +60,7 @@ export class WorkersAbsenceExportLogic {
       this.scheduleModel
     );
 
-    const colLens = workersAbsenceInfoArray[0].map((_, colIndex) =>
+    const colLens = workersAbsenceInfoArray[0].map((absence, colIndex) =>
       Math.max(...workersAbsenceInfoArray.map((row) => row[colIndex]?.toString().length ?? 0))
     );
 
@@ -148,6 +149,7 @@ export class WorkersAbsenceExportLogic {
   }
 
   private createAbsenceInfoSection(scheduleModel: ScheduleDataModel): AbsenceInfo {
+    scheduleModel = _.cloneDeep(scheduleModel);
     const cellsToMerge: number[][] = [];
     const names = Object.keys(scheduleModel.employee_info?.type);
     const month = scheduleModel.schedule_info.month_number;


### PR DESCRIPTION
Był problem z tym, że próbowaliśmy zmodyfikować obiekt który był zamrożony. Można trochę więcej o tym poczytać [tutaj](https://stackoverflow.com/questions/53420055/error-while-sorting-array-of-objects-cannot-assign-to-read-only-property-2-of/53420326)


Może pojawić się sensowne pytanie dlaczego obiekt był zamrożony. 
Prawdopodobnie, jest to funkcjonalność udostępniania zapewniana przez funkcje utworzone za pomocą funkcji `createSelector`. 
Nie znalazłem tego w dokumentacji, ale napisałem prosty test który to demonstruje.


Próbujemy zmienić coś przez referencję w obiekcie zwróconym ze stanu.

![image](https://user-images.githubusercontent.com/21079319/122637651-2ec01200-d0f0-11eb-865f-fd1b4a46646f.png)

Dostajemy taki błąd 

![image](https://user-images.githubusercontent.com/21079319/122637685-5dd68380-d0f0-11eb-85e6-6b865e45e8e5.png)





